### PR TITLE
Adding support for using https (ssl) to access keystone.

### DIFF
--- a/keystoneclient/client.py
+++ b/keystoneclient/client.py
@@ -38,8 +38,11 @@ class HTTPClient(httplib2.Http):
 
     def __init__(self, username=None, tenant_id=None, tenant_name=None,
                  password=None, auth_url=None, region_name=None, timeout=None,
-                 endpoint=None, token=None):
-        super(HTTPClient, self).__init__(timeout=timeout)
+                 endpoint=None, token=None, ca_certs=None,
+                 disable_tls_verify=False):
+        super(HTTPClient, self).__init__(timeout=timeout,
+                 ca_certs=ca_certs,
+                 disable_ssl_certificate_validation=disable_tls_verify)
         self.username = username
         self.tenant_id = tenant_id
         self.tenant_name = tenant_name

--- a/keystoneclient/v2_0/client.py
+++ b/keystoneclient/v2_0/client.py
@@ -46,6 +46,10 @@ class Client(client.HTTPClient):
                             instantiation.(optional)
     :param integer timeout: Allows customization of the timeout for client
                             http requests. (optional)
+    :param string ca_certs: Filename of the CA certificates to use when using
+                            ssl. (optional)
+    :param bool disable_tls_verify: Flag to disable certificate verification
+                            when using ssl.  The default is False. (optional)
 
     Example::
 


### PR DESCRIPTION
We wanted to make sure our credentials were not being passed without protection.  The underlying httplib2 connection understands the SSL part though we need to expose some options up through to allow setting the ca certificate(s) file or disabling the certificate verification.
