### PR TITLE
Replace obsolete printt method by using get_string and builtin print function

### DIFF
--- a/keystoneclient/utils.py
+++ b/keystoneclient/utils.py
@@ -34,14 +34,14 @@ def print_list(objs, fields, formatters={}):
                 row.append(data)
         pt.add_row(row)
 
-    pt.printt(sortby=fields[0])
+    print(pt.get_string(sortby=fields[0]))
 
 
 def print_dict(d):
     pt = prettytable.PrettyTable(['Property', 'Value'], caching=False)
     pt.aligns = ['l', 'l']
     [pt.add_row(list(r)) for r in d.iteritems()]
-    pt.printt(sortby='Property')
+    print(pt.get_string(sortby='Property'))
 
 
 def find_resource(manager, name_or_id):


### PR DESCRIPTION
Since r42 (April 29, 2012) prettytable no longer supports the printt() method.
See http://code.google.com/p/prettytable/source/detail?r=42
