### PR TITLE
adminURL may not be available, prevent crash

### DIFF
--- a/keystoneclient/v2_0/client.py
+++ b/keystoneclient/v2_0/client.py
@@ -183,7 +183,9 @@ class Client(client.HTTPClient):
             self.auth_token = self.auth_ref.auth_token
             if self.auth_ref.scoped:
                 if self.management_url is None:
-                    self.management_url = self.auth_ref.management_url[0]
+                    self.management_url = self.auth_ref.management_url
+                    if isinstance(self.management_url, tuple):
+                        self.management_url = self.management_url[0]
                 self.tenant_name = self.auth_ref.tenant_name
                 self.tenant_id = self.auth_ref.tenant_id
                 self.user_id = self.auth_ref.user_id


### PR DESCRIPTION
If there's no adminURL endpoint in the serviceCatalog (ie. in a objtect-store,
in Rackspace identity service there's onlu publicURL and internalURL), unconditionally
accessing the first element of management_url property of AccesInfo may raise:

  Authorization Failed: 'NoneType' object has no attribute '**getitem**'

This change verifies that management_url is a tuple, otherwise management_url will be None.
