### PR TITLE
Set logging to development mode(raiseExceptions) only on debug.

### DIFF
--- a/keystoneclient/client.py
+++ b/keystoneclient/client.py
@@ -79,6 +79,9 @@ class HTTPClient(httplib2.Http):
             ch = logging.StreamHandler()
             _logger.setLevel(logging.DEBUG)
             _logger.addHandler(ch)
+	else:
+	    logging.raiseExceptions = 0
+	    
 
     def authenticate(self):
         """ Authenticate against the Identity API.


### PR DESCRIPTION
Set logging to development mode(raiseExceptions) only on debug.
Eliminate 'No handlers could be found for logger' message.
