### PR TITLE
Update keystoneclient/service_catalog.py

### DIFF
--- a/keystoneclient/service_catalog.py
+++ b/keystoneclient/service_catalog.py
@@ -73,7 +73,7 @@ class ServiceCatalog(object):
                 if not filter_value or endpoint.get(attr) == filter_value:
                     return endpoint[endpoint_type]
 
-        raise exceptions.EndpointNotFound('Endpoint not found.')
+        raise exceptions.EndpointNotFound('Endpoint not found: %s' % service_type)
 
     def get_endpoints(self, service_type=None, endpoint_type=None):
         """Fetch and filter endpoints for the specified service(s).


### PR DESCRIPTION
Sometimes it is nice to know what it was trying to find when it failed to find something. A trace in my case did show the endpoint_type, but maybe that also would need to be added ?

As I'm no Python guy: I might be doing it the wrong way. I don't know if service_type could also be None or something along those lines and just crash.

Hope this is useful to you.
