### PR TITLE
setup.py should properly package versioninfo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setuptools.setup(
     entry_points={
         'console_scripts': ['keystone = keystoneclient.shell:main']
     },
-    data_files=[('keystoneclient', ['keystoneclient/versioninfo'])],
+    package_data={'keystoneclient': ['versioninfo']},
 )


### PR DESCRIPTION
setup.py was putting the versioninfo file in two places:

$ sudo python setup.py install --root=/tmp/kc
_snip_
$ find /tmp/kc -name versioninfo
/tmp/kc/usr/keystoneclient/versioninfo
/tmp/kc/usr/lib/python2.6/site-packages/keystoneclient/versioninfo

By using package_data rather than data_files in setup.py the versioninfo
file is only put in the pythonlib dir.
