### PR TITLE
Update utils.py for non-int/uuid id names

### DIFF
--- a/keystoneclient/utils.py
+++ b/keystoneclient/utils.py
@@ -84,6 +84,12 @@ def find_resource(manager, name_or_id):
         return manager.get(name_or_id)
     except (ValueError, exceptions.NotFound):
         pass
+    
+    # there is a chance that the entity is an id that is not uuid
+    try:
+        return manager.get(name_or_id)
+    except (ValueError, exceptions.NotFound):
+        pass
 
     # finally try to find entity by name
     try:


### PR DESCRIPTION
For ldap backends, the id could be just a username. As such, we should try to lookup the user by a string name_or_id.
