### PR TITLE
Fix --os-cache option on Mac OS

### DIFF
--- a/keystoneclient/httpclient.py
+++ b/keystoneclient/httpclient.py
@@ -433,7 +433,7 @@ class HTTPClient(object):
                 auth_ref = keyring.get_password("keystoneclient_auth",
                                                 keyring_key)
                 if auth_ref:
-                    auth_ref = pickle.loads(auth_ref)
+                    auth_ref = pickle.loads(str(auth_ref))
                     if auth_ref.will_expire_soon(self.stale_duration):
                         # token has expired, don't use it
                         auth_ref = None


### PR DESCRIPTION
The --os-cache option on Mac OS is broken and you get the following log message as it's trying to unpickle the auth_ref fetched from the keyring.  The auth token and service catalog ends up being fetched every time.

```
WARNING:keystoneclient.httpclient:Unable to retrieve token from keyring __import__() argument 1 must be string without null bytes, not str
```

The fix is to whack a str() around the result of keyring.get_password() which fixes the problem but makes me want to tear my hair out as it's the wrong way to fix it.  If you dive into the OS X backend for the keyring module (https://bitbucket.org/kang/python-keyring-lib/src/598488b60d2148d4c44e64e9e725cde93a258c75/keyring/backends/OS_X.py?at=default) it does the following awful thing:

```
    # it's a weird hex password, decode it.
    return unicode_str(binascii.unhexlify(hex), 'utf-8')
```

UTF-8 is not a suitable encoding for possible binary data - the keyring module assumes that a "password" is something that's a string which IMHO is why this conversion is being performed.

According to the pickle docs, "By default, the pickle data format uses a printable ASCII representation. This is slightly more voluminous than a binary representation. The big advantage of using printable ASCII (and of some other characteristics of pickle's representation) is that for debugging or recovery purposes it is possible for a human to read the pickled file with a standard text editor."  I guess this means that doing a str() on the result of pickle.loads() will not cause any problems since there will be no multi-byte sequences in the string.

Having --os-cache work is pretty cool.  (-:
