### PR TITLE
Fix s3_token middleware parsing insecure option

### DIFF
--- a/keystoneclient/middleware/s3_token.py
+++ b/keystoneclient/middleware/s3_token.py
@@ -34,6 +34,7 @@ This WSGI component:
 import logging
 
 from oslo.serialization import jsonutils
+from oslo.utils import strutils
 import requests
 import six
 from six.moves import urllib
@@ -116,7 +117,7 @@ class S3Token(object):
         self.request_uri = '%s://%s:%s' % (auth_protocol, auth_host, auth_port)
 
         # SSL
-        insecure = conf.get('insecure', False)
+        insecure = strutils.bool_from_string(conf.get('insecure', False))
         cert_file = conf.get('certfile')
         key_file = conf.get('keyfile')
 


### PR DESCRIPTION
The "insecure" option was being treated as a bool when it was
actually provided as a string. The fix is to parse the string to
a bool.

Closes-Bug: 1411063
Change-Id: Id674f40532215788675c97a8fdfa91d4420347b3