### PR TITLE
Add explicit install_requires on setuptools for pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr>=2.0.0'],
+    install_requires=['setuptools'],
     pbr=True)


### PR DESCRIPTION
Since python-keystoneclient uses pkg_resources,  it should have a
runtime dependency on setuptools. This helps packagers correctly
determine the dependencies, for packaging systems that can remove/skip build-time
dependencies.